### PR TITLE
Remove active support

### DIFF
--- a/lib/nostradamus.rb
+++ b/lib/nostradamus.rb
@@ -55,7 +55,7 @@ class Nostradamus
     date = params[:on] || Date.today
     hours, minutes, seconds = extract_time_from_seconds(time_in_seconds)
 
-    Time.zone.local(date.year, date.month, date.day, hours, minutes)
+    Time.utc(date.year, date.month, date.day, hours, minutes)
   end
 
   private

--- a/nostradamus.gemspec
+++ b/nostradamus.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.2'
 
-  gem.add_dependency 'activesupport', '>= 5.0.0'
   gem.add_dependency 'tzinfo', '>= 0.3.33'
 
   gem.add_development_dependency 'rspec', '>= 3.5.0'

--- a/spec/nostradamus/nostradamus_spec.rb
+++ b/spec/nostradamus/nostradamus_spec.rb
@@ -192,8 +192,8 @@ describe Nostradamus do
       end
 
       it "return a today time object" do
-        expect(described_class.new(43200).to_time).to eq Time.zone.local(today.year, today.month, today.day, 12, 0)
-        expect(described_class.new("12:00").to_time).to eq Time.zone.local(today.year, today.month, today.day, 12, 0)
+        expect(described_class.new(43200).to_time).to eq Time.utc(today.year, today.month, today.day, 12, 0)
+        expect(described_class.new("12:00").to_time).to eq Time.utc(today.year, today.month, today.day, 12, 0)
       end
     end
 
@@ -203,8 +203,8 @@ describe Nostradamus do
       end
 
       it "uses a date to return a time object" do
-        expect(described_class.new(43200).to_time(:on => date)).to eq Time.zone.local(date.year, date.month, date.day, 12, 0)
-        expect(described_class.new("12:00").to_time(:on => date)).to eq Time.zone.local(date.year, date.month, date.day, 12, 0)
+        expect(described_class.new(43200).to_time(:on => date)).to eq Time.utc(date.year, date.month, date.day, 12, 0)
+        expect(described_class.new("12:00").to_time(:on => date)).to eq Time.utc(date.year, date.month, date.day, 12, 0)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,7 @@
 require 'bundler/setup'
-require 'active_support'
-require 'active_support/core_ext'
 require 'tzinfo'
 
 require 'nostradamus'
-
-Time.zone = 'Pacific Time (US & Canada)'
 
 RSpec.configure do |config|
   config.treat_symbols_as_metadata_keys_with_true_values = true


### PR DESCRIPTION
We do not need active support to deal with time frames, we can use UTC
and let the final user decides what to do with it.